### PR TITLE
Update dropdown-modals.md

### DIFF
--- a/Client/UI/dropdown-modals.md
+++ b/Client/UI/dropdown-modals.md
@@ -53,9 +53,10 @@ We can use the documentation's example to make a base/skeleton modal in our comp
 **`components/Trip/LoadModal.js`**
 ```js
 export function LoadModal(props) {
+   
     return (
-        <Modal isOpen={propsmodal} toggle={props.toggled}>
-            <ModalHeader toggle={props.toggled}>Modal title</ModalHeader>
+        <Modal isOpen={props.toggled} toggle={props.toggle}>
+            <ModalHeader toggle={props.toggle}>Modal title</ModalHeader>
             <ModalBody>
                 This is an example modal.
             </ModalBody>


### PR DESCRIPTION
Looking through the react-modal docs, as well as running into several errors. I found out that `isOpen` expects a boolean so since we have the `toggled` prop, we can use that for `isOpen`. And for the `toggle=`, we can use the other prop that we created which uses toggleLoadModal as a function call since `toggle` is expecting a function and not a `boolean`.